### PR TITLE
Add blasting recipes for Lanthanum Ingot

### DIFF
--- a/src/main/resources/data/lightestlamp/recipes/lanthanum_ingot_blasting
+++ b/src/main/resources/data/lightestlamp/recipes/lanthanum_ingot_blasting
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:blasting",
+    "ingredient": {
+        "item": "lightestlamp:raw_lanthanum"
+    },
+    "result": "lightestlamp:lanthanum_ingot",
+    "experience": 0.8,
+    "cookingtime": 100
+}

--- a/src/main/resources/data/lightestlamp/recipes/lanthanum_ingot_dust_blasting
+++ b/src/main/resources/data/lightestlamp/recipes/lanthanum_ingot_dust_blasting
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:blasting",
+    "ingredient": {
+        "item": "lightestlamp:lanthanum_dust"
+    },
+    "result": "lightestlamp:lanthanum_ingot",
+    "experience": 0.8,
+    "cookingtime": 100
+}

--- a/src/main/resources/data/lightestlamp/recipes/lanthanum_ingot_ore_blasting
+++ b/src/main/resources/data/lightestlamp/recipes/lanthanum_ingot_ore_blasting
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:blasting",
+    "ingredient": {
+        "item": "lightestlamp:lanthanum_ore"
+    },
+    "result": "lightestlamp:lanthanum_ingot",
+    "experience": 0.8,
+    "cookingtime": 100
+}


### PR DESCRIPTION
I don't know how to make this PR for every single branch, but it should definitely go in every single branch.
As an ore, the lanthanum smelting recipes should also be able to be performed in a Blast Furnace. This PR adds matching blast furnace recipes to the smelting recipes for Lanthanum.